### PR TITLE
Added optional argument to remove www subdomains

### DIFF
--- a/dns2snort.py
+++ b/dns2snort.py
@@ -21,14 +21,14 @@ parser = argparse.ArgumentParser(
                      @3XPlo1T2
                 ---------------------
 Generates DNS snort rules from a list of domains.
-Usage: dns2rule.py -i <infile> -o <outfile>
+Usage: dns2rule.py -i <infile> -o <outfile> -s 1000000
 Infile format:
 www.evil.com
 Outfile format:
 alert udp $HOME_NET any -> $EXTERNAL_NET 53 (msg:"BLACKLIST DNS known malware domain www.evil.com"; flow:to_server; byte_test:1,!&,0xF8,2; content:"|03|www|04|evil|03|com|00|"; fast_pattern:only; metadata:service dns;  sid:1000000; rev:1;)
 '''))
 
-#Infile, outfile, and sid arguments via ArgParse. All required.
+#Infile, outfile, and sid arguments via ArgParse are all required.
 
 parser.add_argument('-i', dest="infile", required=True,
                     help="The name of the file containing a list of Domains, One domain per line.")

--- a/dns2snort.py
+++ b/dns2snort.py
@@ -6,6 +6,7 @@
 
 import argparse
 import textwrap
+import re
 
 #Initialize argparse and print the big ass description and help usage block if -h or --help is used
 
@@ -34,6 +35,7 @@ parser.add_argument('-i', dest="infile", required=True,
 parser.add_argument('-o', dest="outfile", required=True, help="The name of the file to output your snort rules to.")
 parser.add_argument('-s', dest="sid", type=int, required=True,
                     help="The snort sid to start numbering incrementally at. This number should be between 1000000 and 2000000.")
+parser.add_argument('-w', dest="www", required=False, action='store_true', help="Remove the 'www' subdomain from domains that have it.")
 args = parser.parse_args()
 
 #This is a small check to ensure -s is set to a valid value between one and two million - the local rules range.
@@ -58,6 +60,8 @@ with open(args.outfile, 'w') as fout:
     with open(args.infile, 'r') as f:
         for line in f:
             domain = line.rstrip()
+            if args.www == True: 
+                domain = re.sub('^www\.', '', domain, flags=re.IGNORECASE)
             segment = domain.split('.')
             if len(segment) == 1:
                 sega = (hex(len(segment[0])))[2:]

--- a/readme.txt
+++ b/readme.txt
@@ -6,10 +6,11 @@ Purpose: Given a file containing a list of fully qualified DNS domains, generate
 Requires: argparse, textwrap, python 2.7
 Tested on: OSX, Ubuntu, Debian
 
-Options (all fields except -h are required!):
+Options (INFILE, OUTFILE, and SID arguments are all required!):
 -i : input file. Point the script to the file that contains the list of domains (one domain per line)
 -o : output file: File to output your new snort rules
 -s : SID. This is integer value that must be between 1000000 and 2000000 (one million and two million)
+-w : Remove the 'www' subdomain from domains that have it.
 -h : prints out the most badass help message you've ever seen.
 
 This script supports TLDS, and FQDNS up to four subdomains deep - see the example below, in addition to the sampledns.txt and sample.rules files provided with this script.


### PR DESCRIPTION
Most websites that have a DNS record for the www subdomain will also work with the apex domain name. If enabled, this switch will only remove "www." if it's at the beginning of the FQDN.
